### PR TITLE
Use crypto:strong_rand_bytes() instead of crypto:rand_bytes()

### DIFF
--- a/src/mochiweb_multipart.erl
+++ b/src/mochiweb_multipart.erl
@@ -38,7 +38,7 @@ parts_to_body([{Start, End, Body}], ContentType, Size) ->
     {HeaderList, Body};
 parts_to_body(BodyList, ContentType, Size) when is_list(BodyList) ->
     parts_to_multipart_body(BodyList, ContentType, Size,
-                            mochihex:to_hex(crypto:rand_bytes(8))).
+                            mochihex:to_hex(crypto:strong_rand_bytes(8))).
 
 %% @spec parts_to_multipart_body([bodypart()], ContentType::string(),
 %%                               Size::integer(), Boundary::string()) ->

--- a/src/mochiweb_session.erl
+++ b/src/mochiweb_session.erl
@@ -122,7 +122,7 @@ gen_hmac(ExpirationTime, Data, SessionKey, Key) ->
 -else.
 -spec encrypt_data(binary(), binary()) -> binary().
 encrypt_data(Data, Key) ->
-    IV = crypto:rand_bytes(16),
+    IV = crypto:strong_rand_bytes(16),
     Crypt = crypto:block_encrypt(aes_cfb128, Key, IV, Data),
     <<IV/binary, Crypt/binary>>.
 


### PR DESCRIPTION
crypto:rand_bytes() is removed in OTP-20.